### PR TITLE
Issue #19 reset password link and reset page

### DIFF
--- a/src/app/_components/forgot-pass-button/forgot-pass-button.component.css
+++ b/src/app/_components/forgot-pass-button/forgot-pass-button.component.css
@@ -1,0 +1,3 @@
+.btn-xs {
+  color: #2968ed;
+}

--- a/src/app/_components/forgot-pass-button/forgot-pass-button.component.html
+++ b/src/app/_components/forgot-pass-button/forgot-pass-button.component.html
@@ -1,0 +1,1 @@
+<button (click)="dialogShow()" class="btn btn-xs">Forgot Password ...</button>

--- a/src/app/_components/forgot-pass-button/forgot-pass-button.component.spec.ts
+++ b/src/app/_components/forgot-pass-button/forgot-pass-button.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ForgotPassButtonComponent } from './forgot-pass-button.component';
+
+describe('ForgotPassButtonComponent', () => {
+  let component: ForgotPassButtonComponent;
+  let fixture: ComponentFixture<ForgotPassButtonComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ForgotPassButtonComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ForgotPassButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/_components/forgot-pass-button/forgot-pass-button.component.ts
+++ b/src/app/_components/forgot-pass-button/forgot-pass-button.component.ts
@@ -1,0 +1,28 @@
+import { Component, OnInit } from '@angular/core';
+import { MatDialog } from '@angular/material';
+
+import { ForgotPasswordComponent } from '../../_dialogs/index';
+
+@Component({
+  selector: 'app-forgot-pass-button',
+  templateUrl: './forgot-pass-button.component.html',
+  styleUrls: ['./forgot-pass-button.component.css']
+})
+export class ForgotPassButtonComponent implements OnInit {
+
+  constructor(public dialog: MatDialog) { }
+
+  ngOnInit() {
+  }
+
+  dialogShow() {
+  	let dialogRef = this.dialog.open(ForgotPasswordComponent, {
+  		data: {}
+  	});
+
+  	dialogRef.afterClosed().subscribe(result => {
+      console.log('The forgot password dialog was closed');
+    });
+  }
+
+}

--- a/src/app/_components/index.ts
+++ b/src/app/_components/index.ts
@@ -1,2 +1,3 @@
+export * from './forgot-pass-button/forgot-pass-button.component';
 export * from './loader/loader.component';
 export * from './user-reg-button/user-reg-button.component';

--- a/src/app/_components/loader/loader.component.css
+++ b/src/app/_components/loader/loader.component.css
@@ -1,7 +1,7 @@
 /* Absolute Center Spinner */
 .loading-indicator {
   position: fixed;
-  z-index: 999;
+  z-index: 1001;
   height: 2em;
   width: 2em;
   overflow: show;

--- a/src/app/_components/user-reg-button/user-reg-button.component.ts
+++ b/src/app/_components/user-reg-button/user-reg-button.component.ts
@@ -25,7 +25,6 @@ export class UserRegButtonComponent implements OnInit {
 
     dialogRef.afterClosed().subscribe(result => {
       console.log('The dialog was closed');
-
     });
 
     if (this.showDialog) {

--- a/src/app/_dialogs/forgot-password/forgot-password.component.css
+++ b/src/app/_dialogs/forgot-password/forgot-password.component.css
@@ -1,0 +1,3 @@
+.mat-form-field {
+	width: 300px;
+}

--- a/src/app/_dialogs/forgot-password/forgot-password.component.html
+++ b/src/app/_dialogs/forgot-password/forgot-password.component.html
@@ -1,0 +1,21 @@
+<div mat-dialog-content>
+	<p [ngClass]="{'text-danger': !forgotSuccess}">
+	  {{ forgotResponse }}
+	</p>
+	<div class="generate-forgot-password-email" [hidden]="forgotSuccess">
+		<h3>Send new password link</h3>
+		<form (ngSubmit)="onSubmit($event)" [formGroup]="forgotPassForm">
+			<mat-form-field>
+		    <input matInput placeholder="Email Address (Your User Name)"
+		           formControlName="email"
+		           required
+		           id="forgot-password-email"
+		           [(ngModel)]="forgotPasswordEmail"
+		           name="forgot-password-email">
+
+		    <mat-error *ngIf="forgotPassForm.controls['email'].errors && !forgotPassForm.controls['email'].pristine">{{getErrorMessage()}}</mat-error>
+		  </mat-form-field>
+		  <button mat-raised-button color="primary" [disabled]="forgotPassForm.invalid" type="submit" [formGroup]="forgotPassForm">Submit</button>
+		</form>
+	</div>
+</div>

--- a/src/app/_dialogs/forgot-password/forgot-password.component.spec.ts
+++ b/src/app/_dialogs/forgot-password/forgot-password.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ForgotPasswordComponent } from './forgot-password.component';
+
+describe('ForgotPasswordComponent', () => {
+  let component: ForgotPasswordComponent;
+  let fixture: ComponentFixture<ForgotPasswordComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ForgotPasswordComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ForgotPasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/_dialogs/forgot-password/forgot-password.component.ts
+++ b/src/app/_dialogs/forgot-password/forgot-password.component.ts
@@ -1,0 +1,55 @@
+import { Component, OnInit, Inject } from '@angular/core';
+import { FormControl, Validators, FormGroup, FormBuilder, AbstractControl } from '@angular/forms';
+import { HttpErrorResponse, HttpHeaders, HttpClient } from "@angular/common/http";
+import { environment } from "../../../environments/environment";
+
+@Component({
+  selector: 'app-forgot-password',
+  templateUrl: './forgot-password.component.html',
+  styleUrls: ['./forgot-password.component.css']
+})
+export class ForgotPasswordComponent implements OnInit {
+	forgotResponse: string;
+	forgotSuccess: boolean = false;
+	forgotPasswordEmail: string;
+	forgotPassForm: FormGroup;
+
+  constructor(private http: HttpClient, @Inject(FormBuilder) fb: FormBuilder) {
+  	this.forgotPassForm = fb.group({
+      email: new FormControl(this.forgotPasswordEmail, [Validators.required, Validators.email]),
+    });
+  }
+
+  ngOnInit() {
+  }
+
+  /*
+   * Submits the form and sends HTTP request for new password link
+   */
+  onSubmit(event) {
+  	this.http.post(environment.host_url + '/auth/forgot-pass/link',
+      {"email": this.forgotPasswordEmail }, {
+        observe: 'response',
+        // withCredentials: true,
+        headers: new HttpHeaders()
+          .set('content-type', 'application/json')
+      }
+
+    ).subscribe((re) => {
+        let credentials = re.body;
+        this.forgotResponse = credentials['message'];
+        this.forgotSuccess = (credentials['status'] === 'success');
+      },
+      (err: HttpErrorResponse) => {
+        this.forgotResponse = err.error.message;
+        this.forgotSuccess = false;
+      }
+    )
+  }
+
+  getErrorMessage() {
+    return this.forgotPassForm.controls['email'].hasError('required') ? 'You must enter a value' :
+      this.forgotPassForm.controls['email'].hasError('email') ? 'Not a valid email' : '';
+  }
+
+}

--- a/src/app/_dialogs/forgot-password/forgot-password.component.ts
+++ b/src/app/_dialogs/forgot-password/forgot-password.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Inject } from '@angular/core';
-import { FormControl, Validators, FormGroup, FormBuilder, AbstractControl } from '@angular/forms';
+import { FormControl, Validators, FormGroup, FormBuilder } from '@angular/forms';
 import { HttpErrorResponse, HttpHeaders, HttpClient } from "@angular/common/http";
 import { environment } from "../../../environments/environment";
 
@@ -27,7 +27,7 @@ export class ForgotPasswordComponent implements OnInit {
    * Submits the form and sends HTTP request for new password link
    */
   onSubmit(event) {
-  	this.http.post(environment.host_url + '/auth/forgot-pass/link',
+  	this.http.post(environment.host_url + '/auth/reset_pass/link',
       {"email": this.forgotPasswordEmail }, {
         observe: 'response',
         // withCredentials: true,

--- a/src/app/_dialogs/index.ts
+++ b/src/app/_dialogs/index.ts
@@ -1,3 +1,4 @@
+export * from './forgot-password/forgot-password.component';
 export * from './login-fail/login-fail.component';
 export * from './terms/terms.component';
 export * from './user-registration/user-registration.component';

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,6 +7,7 @@ import { AboutComponent } from './about/about.component';
 import { AssaysComponent } from './assays/assays.component';
 import { AssayDataComponent } from './assay-data/assay-data.component';
 import { ConfirmEmailComponent } from './confirm-email/confirm-email.component';
+import { ResetPasswordComponent } from './reset-password/reset-password.component';
 
 const appRoutes: Routes = [
   { path: '', component: CompoundSearchComponent, pathMatch: 'full' },
@@ -14,7 +15,8 @@ const appRoutes: Routes = [
   { path: 'assays', component: AssaysComponent, pathMatch: 'full' },
   { path: 'assays/:aid', component: AssayDataComponent, pathMatch: 'full' },
   { path: 'compound_data/:qid', component: CompoundDataComponent, pathMatch: 'full' },
-  { path: 'confirm/:cid', component: ConfirmEmailComponent, pathMatch: 'full' }
+  { path: 'confirm/:cid', component: ConfirmEmailComponent, pathMatch: 'full' },
+  { path: 'reset_pass/:rid', component: ResetPasswordComponent, pathMatch: 'full' }
 ];
 
 @NgModule({
@@ -25,4 +27,4 @@ const appRoutes: Routes = [
 })
 export class AppRoutingModule { }
 
-export const routedComponents = [CompoundSearchComponent, AboutComponent, AssaysComponent, AssayDataComponent, CompoundDataComponent, ConfirmEmailComponent];
+export const routedComponents = [CompoundSearchComponent, AboutComponent, AssaysComponent, AssayDataComponent, CompoundDataComponent, ConfirmEmailComponent, ResetPasswordComponent];

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -93,6 +93,7 @@ import { ForgotPasswordComponent, LoginFailComponent, TermsComponent, UserRegist
 import { LoaderInterceptorService } from './_interceptors/loader-interceptor.service';
 import { LoaderStateService, LoginStateService } from './_services/index';
 import { ConfirmEmailComponent } from './confirm-email/confirm-email.component';
+import { ResetPasswordComponent } from './reset-password/reset-password.component';
 
 @NgModule({
   exports: [
@@ -181,7 +182,8 @@ export class MaterialModule {}
     TermsComponent,
     LoginFailComponent,
     LoaderComponent,
-    ForgotPasswordComponent
+    ForgotPasswordComponent,
+    ResetPasswordComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -88,8 +88,8 @@ import { AssayTypeBtnComponent } from './assay-type-btn/assay-type-btn.component
 import { AssayPaginationComponent } from './assay-pagination/assay-pagination.component';
 import { CmpdTooltipComponent } from './cmpd-tooltip/cmpd-tooltip.component';
 
-import { LoaderComponent, UserRegButtonComponent } from './_components/index';
-import { LoginFailComponent, TermsComponent, UserRegistrationComponent } from './_dialogs/index';
+import { ForgotPassButtonComponent, LoaderComponent, UserRegButtonComponent } from './_components/index';
+import { ForgotPasswordComponent, LoginFailComponent, TermsComponent, UserRegistrationComponent } from './_dialogs/index';
 import { LoaderInterceptorService } from './_interceptors/loader-interceptor.service';
 import { LoaderStateService, LoginStateService } from './_services/index';
 import { ConfirmEmailComponent } from './confirm-email/confirm-email.component';
@@ -177,9 +177,11 @@ export class MaterialModule {}
     UserRegistrationComponent,
     UserLoginComponent,
     UserRegButtonComponent,
+    ForgotPassButtonComponent,
     TermsComponent,
     LoginFailComponent,
-    LoaderComponent
+    LoaderComponent,
+    ForgotPasswordComponent
   ],
   imports: [
     BrowserModule,
@@ -226,7 +228,8 @@ export class MaterialModule {}
     // UserRegComponent,
     UserRegistrationComponent,
     TermsComponent,
-    LoginFailComponent
+    LoginFailComponent,
+    ForgotPasswordComponent
   ],
 
   bootstrap: [AppComponent]

--- a/src/app/confirm-email/confirm-email.component.ts
+++ b/src/app/confirm-email/confirm-email.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { FormControl, Validators, FormGroup, FormBuilder, AbstractControl } from '@angular/forms';
+import { FormControl, Validators, FormGroup, FormBuilder } from '@angular/forms';
 import { HttpErrorResponse, HttpHeaders, HttpClient } from '@angular/common/http';
 
 import { environment } from '../../environments/environment';
@@ -28,8 +28,6 @@ export class ConfirmEmailComponent implements OnInit {
   }
 
   ngOnInit() {
-  	console.log(this.cid);
-  	console.log(environment.host_url + '/auth/confirm' + this.cid);
   	this.http.post(environment.host_url + '/auth/confirm',
   		{"token": this.cid},
   		{

--- a/src/app/reset-password/reset-password.component.html
+++ b/src/app/reset-password/reset-password.component.html
@@ -1,0 +1,34 @@
+<p>
+  {{ resetResponse }}
+</p>
+
+<form (ngSubmit)="onSubmit($event)" [formGroup]="resetPasswordForm" [hidden]="!resetReady || resetSuccess">
+	<div>
+		<mat-form-field>
+		  <input matInput placeholder="Password" id="resetPassword" [type]="'password'"
+		         required
+		         name="resetPassword"
+		         formControlName="password"
+		         [(ngModel)]="resetPassword"
+		         >
+		  <mat-error *ngIf="resetPasswordForm.controls['password'].errors
+		                    && !resetPasswordForm.controls['password'].pristine"
+		             [hidden]="!resetPasswordForm.controls['password'].hasError('minLength')"
+		  >8 characters minimum</mat-error>
+		</mat-form-field>
+	</div>
+	<div>
+		<mat-form-field>
+		  <input matInput placeholder="Confirm Password" id="confirmPassword" [type]="'password'"
+		         required
+		         formControlName="confirmPassword"
+		         name="confirmPassword"
+		         >
+		  <mat-error *ngIf="resetPasswordForm.controls['confirmPassword'].errors
+		                    && !resetPasswordForm.controls['confirmPassword'].pristine"
+		             [hidden]="!resetPasswordForm.controls['confirmPassword'].hasError('MatchPassword')"
+		  >Passwords don't match!</mat-error>
+		</mat-form-field>
+	</div>
+	<button mat-raised-button color="primary" [disabled]="resetPasswordForm.invalid" type="submit" [formGroup]="resetPasswordForm">Submit</button>
+</form>

--- a/src/app/reset-password/reset-password.component.spec.ts
+++ b/src/app/reset-password/reset-password.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ResetPasswordComponent } from './reset-password.component';
+
+describe('ResetPasswordComponent', () => {
+  let component: ResetPasswordComponent;
+  let fixture: ComponentFixture<ResetPasswordComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ResetPasswordComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ResetPasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/reset-password/reset-password.component.ts
+++ b/src/app/reset-password/reset-password.component.ts
@@ -1,0 +1,98 @@
+import { Component, OnInit, Inject } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { FormControl, Validators, FormGroup, FormBuilder, AbstractControl } from '@angular/forms';
+import { HttpErrorResponse, HttpHeaders, HttpClient } from '@angular/common/http';
+
+import { environment } from '../../environments/environment';
+
+export class PasswordValidation {
+
+  static MatchPassword(AC: AbstractControl) {
+    let password = AC.get('password').value;
+    let confirmPassword = AC.get('confirmPassword').value;
+    if(password != confirmPassword) {
+      AC.get('confirmPassword').setErrors( {MatchPassword: true});
+    } else {
+      AC.get('confirmPassword').setErrors( null);
+      return null
+    }
+  }
+}
+
+@Component({
+  selector: 'app-reset-password',
+  templateUrl: './reset-password.component.html',
+  styleUrls: ['./reset-password.component.css']
+})
+export class ResetPasswordComponent implements OnInit {
+	rid: string;
+	uid: string;
+	resetResponse: string;
+	resetReady: boolean = false;
+	resetSuccess: boolean = false;
+	resetPassword: string;
+	confirmPassword: string
+	resetPasswordForm: FormGroup;
+
+  constructor(private route: ActivatedRoute, private http: HttpClient, @Inject(FormBuilder) fb: FormBuilder) {
+  	route.params.subscribe(params => {
+  		this.rid = params['rid'];
+  	});
+
+  	this.resetPasswordForm = fb.group({
+      password: [this.resetPassword, Validators.minLength(8)],
+      confirmPassword: [this.confirmPassword, Validators.minLength(8)],
+      }, {validator: PasswordValidation.MatchPassword});
+  }
+
+  ngOnInit() {
+  	this.http.post(environment.host_url + '/auth/reset_pass/check',
+  		{"token": this.rid},
+  		{
+  			observe: 'response',
+  			headers: new HttpHeaders()
+  				.set('content-type', 'application/json')
+  		}
+  	).subscribe(res => {
+  		this.resetResponse = res.body['message'];
+  		if (res.body['status'] == 'success') {
+  			this.resetReady = true;
+  			this.uid = res.body['data']['user_id'];
+  		}
+  	},
+  	(err: HttpErrorResponse) => {
+  		console.log(err);
+  		this.resetResponse = err.error.message;
+  		this.resetReady = false;
+  	});
+  }
+
+  /*
+   * Submits the form and sends HTTP request to change password
+   */
+  onSubmit(event) {
+  	this.http.post(environment.host_url + '/auth/reset_pass',
+      {
+      	'user_id': this.uid,
+      	'password': this.resetPassword
+      },
+      {
+        observe: 'response',
+        // withCredentials: true,
+        headers: new HttpHeaders()
+          .set('content-type', 'application/json')
+      }
+
+    ).subscribe((re) => {
+        let credentials = re.body;
+        this.resetResponse = credentials['message'];
+        this.resetSuccess = (credentials['status'] === 'success');
+      },
+      (err: HttpErrorResponse) => {
+        this.resetResponse = err.error.message;
+        this.resetSuccess = false;
+      }
+    )
+  }
+
+}

--- a/src/app/user-login/user-login.component.html
+++ b/src/app/user-login/user-login.component.html
@@ -26,4 +26,5 @@
       <button class="login-button" mat-raised-button color="primary" type="submit">Login</button>
   </form>
   <app-reg-user-dialog></app-reg-user-dialog>
+  <app-forgot-pass-button></app-forgot-pass-button>
 </ng-template>


### PR DESCRIPTION
Created dialog attached to login area for creating a reset password link, user must have confirmed email. Reset password page with validation. [Corresponds to back end update](https://github.com/sebotic/repurpos-backend/pull/3)